### PR TITLE
bump version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,4 +42,4 @@ jobs:
           serviceAccountJsonPlainText: ${{ secrets.SERVICE_ACCOUNT_JSON }}
           packageName: br.com.messore.tech.lightning.nodes
           releaseFiles: app/build/outputs/bundle/release/app-release.aab
-          track: qa
+          track: internal

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         applicationId = "br.com.messore.tech.lightning.nodes"
         minSdk = 26
         targetSdk = 35
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = 2
+        versionName = "1.0.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
This pull request includes minor updates to the deployment configuration and the Android app versioning. The changes ensure the app is released to the correct track and reflect a new version release.

Deployment configuration:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L45-R45): Changed the release track from `qa` to `internal` to update where the app is deployed.

App versioning:

* [`app/build.gradle.kts`](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46L21-R22): Incremented the `versionCode` from 1 to 2 and updated the `versionName` from "1.0" to "1.0.1" to reflect a new app release.